### PR TITLE
JSON API for needs collection

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem 'kaminari', '0.14.1'
 gem 'airbrake', '~> 4.1.0'
 gem 'cancan', '1.6.10'
 gem 'lrucache', '0.1.4'
+gem 'link_header', '0.0.8'
 
 group :development, :test do
   gem 'jasmine', '2.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,6 +127,7 @@ GEM
       actionpack (>= 3.0.0)
       activesupport (>= 3.0.0)
     kgio (2.9.3)
+    link_header (0.0.8)
     loofah (2.0.1)
       nokogiri (>= 1.5.9)
     lrucache (0.1.4)
@@ -253,6 +254,7 @@ DEPENDENCIES
   jasmine (= 2.1.0)
   jquery-rails
   kaminari (= 0.14.1)
+  link_header (= 0.0.8)
   lrucache (= 0.1.4)
   pg
   rails (~> 4.2.0)

--- a/app/controllers/needs_controller.rb
+++ b/app/controllers/needs_controller.rb
@@ -26,6 +26,10 @@ class NeedsController < ApplicationController
                   filename: "#{params["organisation_id"]}.csv",
                   type: "text/csv; charset=utf-8"
       end
+      format.json do
+        presenter = NeedResultSetPresenter.new(@needs, view_context, :scope_params => params.slice(:ids))
+        render json: presenter.as_json
+      end
     end
   end
 
@@ -170,5 +174,13 @@ private
       key = "tag_ids_of_type_#{tag_type.id}"
       whitelisted[key] = params[:need][key]
     end
+  end
+
+  def response_info(status)
+    {
+      _response_info: {
+        status: status
+      }
+    }
   end
 end

--- a/app/presenters/basic_need_presenter.rb
+++ b/app/presenters/basic_need_presenter.rb
@@ -1,0 +1,15 @@
+class BasicNeedPresenter
+  def initialize(need)
+    @need = need
+  end
+
+  def as_json
+    {
+      id: @need.need_id,
+      role: @need.role,
+      goal: @need.goal,
+      benefit: @need.benefit,
+      met_when: @need.met_when
+    }
+  end
+end

--- a/app/presenters/need_result_set_presenter.rb
+++ b/app/presenters/need_result_set_presenter.rb
@@ -1,0 +1,63 @@
+require 'link_header'
+
+class NeedResultSetPresenter
+  def initialize(needs, view_context, options = {})
+    @needs = needs
+    @view_context = view_context
+    @scope_params = options[:scope_params] || {}
+  end
+
+  def as_json
+    {
+      _response_info: {
+        status: "ok",
+        links: links.map {|l| { "href" => l.href }.merge(l.attrs) }
+      },
+      total: @needs.total_count,
+      current_page: @needs.current_page,
+      pages: @needs.total_pages,
+      start_index: start_index,
+      page_size: @needs.to_a.size,
+      results: results
+    }
+  end
+
+  def links
+    @links ||= build_links
+  end
+
+  private
+  def results
+    @needs.map {|need|
+      BasicNeedPresenter.new(need).as_json
+    }
+  end
+
+  def build_links
+    [].tap {|links|
+
+      unless @needs.first_page?
+        links << LinkHeader::Link.new(
+          @view_context.needs_url(@scope_params.merge(page: @needs.current_page-1)),
+          [["rel", "previous"]]
+        )
+      end
+
+      unless @needs.last_page?
+        links << LinkHeader::Link.new(
+          @view_context.needs_url(@scope_params.merge(page: @needs.current_page+1)),
+          [["rel", "next"]]
+        )
+      end
+
+      links << LinkHeader::Link.new(
+        @view_context.needs_url(@scope_params.merge(page: @needs.current_page)),
+        [["rel", "self"]]
+      )
+    }
+  end
+
+  def start_index
+    @needs.offset_value+1
+  end
+end

--- a/app/presenters/need_status_presenter.rb
+++ b/app/presenters/need_status_presenter.rb
@@ -1,0 +1,9 @@
+class NeedStatusPresenter
+  def initialize(need_status)
+    @need_status = need_status
+  end
+
+  def as_json
+    @need_status.present? ? @need_status.attributes.except("_id") : nil
+  end
+end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -59,7 +59,7 @@ Devise.setup do |config|
   # given strategies, for example, `config.http_authenticatable = [:database]` will
   # enable it only for database authentication. The supported strategies are:
   # :database      = Support basic authentication with authentication key + password
-  # config.http_authenticatable = false
+  config.http_authenticatable = true
 
   # If 401 status code should be returned for AJAX requests. True by default.
   # config.http_authenticatable_on_xhr = true

--- a/spec/presenters/basic_need_presenter_spec.rb
+++ b/spec/presenters/basic_need_presenter_spec.rb
@@ -1,0 +1,17 @@
+RSpec.describe BasicNeedPresenter do
+
+  describe 'JSON representation' do
+    it 'represents a need as JSON' do
+      tag = create(:tag)
+      need = create(:need, tagged_with: tag)
+      presentation = BasicNeedPresenter.new(need).as_json
+
+      expect(presentation[:id]).to eq(need.id)
+      expect(presentation[:role]).to eq(need.role)
+      expect(presentation[:goal]).to eq(need.goal)
+      expect(presentation[:benefit]).to eq(need.benefit)
+      expect(presentation[:met_when]).to eq(need.met_when)
+    end
+  end
+
+end


### PR DESCRIPTION
- enable http basic auth
- add meta data to JSON response, e.g. pagination
- test for need JSON representation